### PR TITLE
Deployed on test cluster and added config mount

### DIFF
--- a/README_dev.md
+++ b/README_dev.md
@@ -5,4 +5,6 @@
   helm install -f elasticsearch/values-datahot.yaml esdatahot elasticsearch
   helm install -f elasticsearch/values-datawarm.yaml esdatawarm elasticsearch
   helm install eskibana kibana
+
+  helm install -f elasticsearch/values.yaml esstandalone elasticsearch -n elasticsearch
   ```

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -21,14 +21,19 @@ roles:
   - remote_cluster_client
   - transform
 
-replicas: 3
-minimumMasterNodes: 2
+replicas: 1
+minimumMasterNodes: 1
 
 esMajorVersion: ""
 
 # Allows you to add any config files in /usr/share/elasticsearch/config/
 # such as elasticsearch.yml and log4j2.properties
-esConfig: {}
+esConfig:
+  elasticsearch.yml: |
+    xpack.security.enabled: true
+    xpack.security.transport.ssl.enabled: false
+    xpack.security.http.ssl.enabled: false
+    xpack.monitoring.collection.enabled: false
 #  elasticsearch.yml: |
 #    key:
 #      nestedkey: value
@@ -56,7 +61,7 @@ envFrom: []
 # Disable it to use your own elastic-credential Secret.
 secret:
   enabled: true
-  password: "" # generated randomly if not defined
+  password: "changemeonce" # generated randomly if not defined
 
 # A list of secrets and their paths to mount inside the pod
 # This is useful for mounting certificates for security and for mounting
@@ -74,8 +79,10 @@ hostAliases: []
 #  - "bar.local"
 
 image: "docker.elastic.co/elasticsearch/elasticsearch"
-imageTag: "8.0.0-SNAPSHOT"
+imageTag: "7.16.2"
 imagePullPolicy: "IfNotPresent"
+imagePullSecrets:
+  - name: "uvdockerrepo-secret"
 
 podAnnotations: {}
 # iam.amazonaws.com/role: es-cluster
@@ -141,24 +148,45 @@ persistence:
     enabled: false
   annotations: {}
 
-extraVolumes: []
+#extraVolumes: []
+extraVolumes:
+  - name: elastic-hunspell
+    emptyDir: {}
+  - name: elastic-synonyms
+    emptyDir: {}
 # - name: extras
 #   emptyDir: {}
 
-extraVolumeMounts: []
-# - name: extras
-#   mountPath: /usr/share/extras
-#   readOnly: true
+#extraVolumeMounts: []
+extraVolumeMounts:
+  - name: elastic-hunspell
+    mountPath: /usr/share/elasticsearch/config/hunspell
+    readOnly: false
+  - name: elastic-synonyms
+    mountPath: /usr/share/elasticsearch/config/synonyms
+    readOnly: false
 
 extraContainers: []
 # - name: do-something
 #   image: busybox
 #   command: ['do', 'something']
 
-extraInitContainers: []
-# - name: do-something
-#   image: busybox
-#   command: ['do', 'something']
+#extraInitContainers: []
+extraInitContainers:
+  - name: elasticsearch-custom-config-init
+    image: "uvdeployment/videosearch:search_es_v0.0.1"
+    imagePullPolicy: "IfNotPresent"
+    volumeMounts:
+      - name:  elastic-hunspell
+        mountPath: /tmp/hunspell
+      - name:  elastic-synonyms
+        mountPath: /tmp/synonyms
+    command:
+      - bash
+      - -c
+      - |
+        cp -rf /usr/src/app/hunspell/*  /tmp/hunspell
+        cp -rf /usr/src/app/synonyms/*  /tmp/synonyms
 
 # This is the PriorityClass settings as defined in
 # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
@@ -193,8 +221,8 @@ service:
   enabled: true
   labels: {}
   labelsHeadless: {}
-  type: ClusterIP
-  nodePort: ""
+  type: NodePort
+  nodePort: "30003"
   annotations: {}
   httpPortName: http
   transportPortName: transport
@@ -241,8 +269,9 @@ clusterHealthCheckParams: "wait_for_status=green&timeout=1s"
 ##
 schedulerName: ""
 
-imagePullSecrets: []
-nodeSelector: {}
+nodeSelector: 
+   role: server-1a
+
 tolerations: []
 
 # Enabling this will publicly expose your Elasticsearch instance.

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -10,15 +10,17 @@ extraEnvs:
   #- name: "NODE_OPTIONS"
   #  value: "--max-old-space-size=1800"
   - name: "ELASTICSEARCH_USERNAME"
-    valueFrom:
-      secretKeyRef:
-        name: elasticsearch-master-credentials
-        key: username
+    value: "elastic"
+#    valueFrom:
+#      secretKeyRef:
+#        name: elasticsearch-master-credentials
+#        key: username
   - name: "ELASTICSEARCH_PASSWORD"
-    valueFrom:
-      secretKeyRef:
-        name: elasticsearch-master-credentials
-        key: password
+    value: "changemeonce"
+#    valueFrom:
+#      secretKeyRef:
+#        name: elasticsearch-master-credentials
+#        key: password
 #  - name: MY_ENVIRONMENT_VAR
 #    value: the_value_goes_here
 
@@ -127,7 +129,7 @@ service:
   type: NodePort
   loadBalancerIP: ""
   port: 5601
-  nodePort: "30002"
+  nodePort: "30004"
   labels: {}
   annotations: {}
   # cloud.google.com/load-balancer-type: "Internal"


### PR DESCRIPTION
1. Config Mount for Hunspell and Synonym
2. Deployed standalone mode in test cluster